### PR TITLE
Correction ExempleTLScancerFluxForfaitOperateur_HprimXml_semestrielV5.xml : INS est non qualifiée

### DIFF
--- a/facturation/exemples/ExempleTLScancerFluxForfaitOperateur_HprimXml_semestrielV5.xml
+++ b/facturation/exemples/ExempleTLScancerFluxForfaitOperateur_HprimXml_semestrielV5.xml
@@ -30,7 +30,7 @@ X:\emission\divers\hprim\schemaXml\ccam\v2_4\msgEvenementsServeurActes2_4.xsd" v
 					<valeur>6540786534</valeur>
 				</recepteur>
 			</identifiant>
-			<personnePhysique sexe="F" informationQualifiee="oui">
+			<personnePhysique sexe="F" informationQualifiee="non">
 				<nomNaissance>Guilbert</nomNaissance>
 				<prenoms>
 					<prenom>Yvette</prenom>


### PR DESCRIPTION
Correction de la ligne 33 : informationQualifiee = "non" (au lieu de "oui")